### PR TITLE
Allow optional pattern argument to be passed to ALPR

### DIFF
--- a/lib/OpenALPR.js
+++ b/lib/OpenALPR.js
@@ -37,7 +37,7 @@ const COUNTRY_CODES = [
 ];
 
 export class OpenALPR {
-	static async detectBuffer(buff, countryCode = 'us') {
+	static async detectBuffer(buff, countryCode = 'us', pattern = null) {
 		if (!(buff instanceof Buffer))
 			throw new TypeError('buff must be an instance of Buffer.');
 		
@@ -49,8 +49,11 @@ export class OpenALPR {
 		const filePath = `/tmp/${randomString(32)}.jpeg`;
 		await fs.writeFile(filePath, buff);
 
+		const args = ['--country', countryCode, '--json', filePath]
+		if (pattern) args.push('--pattern', pattern);
+
 		// alpr looks like it requires a file on disk to read. Cannot pipe. :'(
-		const ls = spawn('/usr/bin/alpr', ['--country', countryCode, '--json', filePath]);
+		const ls = spawn('/usr/bin/alpr', args);
 		const out = [];
 		const err = [];
 

--- a/lib/OpenALPR.js
+++ b/lib/OpenALPR.js
@@ -44,12 +44,15 @@ export class OpenALPR {
 		if(COUNTRY_CODES.indexOf(countryCode) === -1)
 			throw new TypeError('invalid country code.');
 
+		if(pattern && typeof pattern !== 'string')
+			throw new TypeError('pattern must be a string.');
+
 		// alpr only seems to care if the file extension is a known one
 		// png, jpg, jpeg, bpm (others?) encoding works regardless
 		const filePath = `/tmp/${randomString(32)}.jpeg`;
 		await fs.writeFile(filePath, buff);
 
-		const args = ['--country', countryCode, '--json', filePath]
+		const args = ['--country', countryCode, '--json', filePath];
 		if (pattern) args.push('--pattern', pattern);
 
 		// alpr looks like it requires a file on disk to read. Cannot pipe. :'(

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -69,7 +69,7 @@ export default class Server {
 	}
 	async detect(req, res) {
 		try {
-			const data = await OpenALPR.detectBuffer(req.file.buffer, req.body.country_code);
+			const data = await OpenALPR.detectBuffer(req.file.buffer, req.body.country_code, req.body.pattern);
 			res.status(200).json(data);
 		}
 		catch(err) {


### PR DESCRIPTION
This PR adds the ability to pass a `pattern` argument to `alpr`. This argument is optional. 

Open to feedback and suggestions. Tried to follow existing patterns.